### PR TITLE
getStyles will act as theme style sheet

### DIFF
--- a/src/styles.tsx
+++ b/src/styles.tsx
@@ -1,0 +1,60 @@
+export function getStyles() {
+    const WHITE_COLOR = "#FFFFFF";
+    const BLACK_COLOR = "#000000"
+    const BLUE_COLOR = "#00a3de";
+    const RED_COLOR = "#7c270b";
+    const AXIS_COLOR = "#FFFFFF";
+    const LIGHTGRAY_COLOR = "#f0efef";
+    const BLACKDARK_COLOR = "#1A1B1E";
+    const BLACKLIGHT_COLOR = "#292A29";
+    const GREEN_COLOR = "#31D397";
+
+    return {
+      title: {
+        fill: WHITE_COLOR,
+        fontFamily: "inherit",
+        fontSize: "28px",
+        fontWeight: 700,
+      },
+      labelNumber: {
+        fill: "#ffffff",
+        fontFamily: "inherit",
+        fontSize: "14px"
+      },
+
+      // INDEPENDENT AXIS
+      axisYears: {
+        grid: { strokeWidth: 0 },
+        axis: { stroke: AXIS_COLOR, strokeWidth: 1},
+        ticks: {
+          stroke: AXIS_COLOR,
+          strokeWidth: 1,
+        },
+        tickLabels: {
+          fill: AXIS_COLOR,
+          fontFamily: "inherit",
+          fontSize: "12px"
+        }
+      },
+
+      // DATA SET ONE
+      axisOne: {
+        grid: {
+          strokeWidth: 0
+        },
+        axis: { stroke: AXIS_COLOR, strokeWidth: 1 }, 
+        ticks: { stroke: AXIS_COLOR , strokeWidth: 1 },
+        tickLabels: {
+          fill: AXIS_COLOR,
+          fontFamily: "inherit",
+          fontSize: "12px",
+        }
+      },
+
+      // HEROKU WIDGET BAR STYLES
+      herokuBar: {
+        data: { fill: GREEN_COLOR },
+        labels: { fill: WHITE_COLOR, fontSize: "12px" }
+      }
+    };
+  }

--- a/src/widgets/HerokuCost.tsx
+++ b/src/widgets/HerokuCost.tsx
@@ -8,7 +8,7 @@ import {
   VictoryTheme,
   VictoryLabel
 } from "victory";
-import styled from "styled-components";
+import { getStyles } from "../styles";
 
 
 interface billingPeriod {
@@ -84,8 +84,7 @@ export default class HerokuCost extends React.Component<Props, State> {
     }
 
     const { area } = this.props;
-
-    const styles = this.getStyles();
+    const styles = getStyles();
 
     return (
         <Cell center area={area} style={{ backgroundColor: "#292A29" }}>
@@ -109,11 +108,12 @@ export default class HerokuCost extends React.Component<Props, State> {
             <VictoryAxis style={styles.axisOne} dependentAxis tickFormat={x => `$${x}`} />
             <VictoryBar
               data={this.getData()}
-              style={styles.bar}
+              style={styles.herokuBar}
+              barWidth={40}
               labels={d => `$${d.y}`}
               labelComponent={
                 <VictoryLabel
-                  style={styles.bar.labels}
+                  style={styles.herokuBar.labels}
                 />
               }
             />
@@ -121,64 +121,5 @@ export default class HerokuCost extends React.Component<Props, State> {
         </Cell>
     );
   }
-  getStyles() {
-    const WHITE_COLOR = "#FFFFFF";
-    const BLACK_COLOR = "#000000"
-    const BLUE_COLOR = "#00a3de";
-    const RED_COLOR = "#7c270b";
-    const AXIS_COLOR = "#FFFFFF";
-    const LIGHTGRAY_COLOR = "#f0efef";
-    const BLACKDARK_COLOR = "#1A1B1E";
-    const BLACKLIGHT_COLOR = "#292A29";
-    const GREEN_COLOR = "#31D397";
 
-    return {
-      title: {
-        fill: WHITE_COLOR,
-        fontFamily: "inherit",
-        fontSize: "28px",
-        fontWeight: 700,
-      },
-      labelNumber: {
-        fill: "#ffffff",
-        fontFamily: "inherit",
-        fontSize: "14px"
-      },
-
-      // INDEPENDENT AXIS
-      axisYears: {
-        grid: { strokeWidth: 0 },
-        axis: { stroke: AXIS_COLOR, strokeWidth: 1},
-        ticks: {
-          stroke: AXIS_COLOR,
-          strokeWidth: 1,
-        },
-        tickLabels: {
-          fill: AXIS_COLOR,
-          fontFamily: "inherit",
-          fontSize: "12px"
-        }
-      },
-
-      // DATA SET ONE
-      axisOne: {
-        grid: {
-          strokeWidth: 0
-        },
-        axis: { stroke: AXIS_COLOR, strokeWidth: 1 }, 
-        ticks: { stroke: AXIS_COLOR , strokeWidth: 1 },
-        tickLabels: {
-          fill: AXIS_COLOR,
-          fontFamily: "inherit",
-          fontSize: "12px",
-        }
-      },
-
-      // BAR
-      bar: {
-        data: { fill: GREEN_COLOR },
-        labels: { fill: WHITE_COLOR, fontSize: "12px" }
-      }
-    };
-  }
 }


### PR DESCRIPTION
## This PR consists of the following:

### Separated getStyles from the HerokuCost Widget
- `getStyles()` has been moved into `styles.tsx` so it can be called upon from other files
- common styles can be dropped in here now and used as needed, it will also save us the trouble of manually re-entering styles later on if we decided to change styling elements
-  slight change to the bar width on the HerokuCost Widget
 