### PR TITLE
Applying getStyles() to other widgets

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ class App extends React.Component<Props> {
           height="100vh"
           areas={["a b c d", "e f h g"]}
           columns="4"
-          gap="10px"
+          gap="1px"
         >
           <HerokuCost area="a" socket={this.socket} />
           <AwsCost area="b" socket={this.socket} />

--- a/src/styles.tsx
+++ b/src/styles.tsx
@@ -2,7 +2,7 @@ export function getStyles() {
     const WHITE_COLOR = "#FFFFFF";
     const BLACK_COLOR = "#000000"
     const BLUE_COLOR = "#367BBC";
-    const RED_COLOR = "#7c270b";
+    const RED_COLOR = "#C14C54";
     const AXIS_COLOR = "#FFFFFF";
     const LIGHTGRAY_COLOR = "#f0efef";
     const BLACKDARK_COLOR = "#1A1B1E";
@@ -11,10 +11,22 @@ export function getStyles() {
 
 
     return {
-      title: {
+      herokuTitle: {
         fill: WHITE_COLOR,
         fontFamily: "inherit",
-        fontSize: "28px",
+        fontSize: 28,
+        fontWeight: 700,
+      },
+      AWSTitle: {
+        fill: WHITE_COLOR,
+        fontFamily: "inherit",
+        fontSize: 24,
+        fontWeight: 700,
+      },
+      GCPTitle: {
+        fill: WHITE_COLOR,
+        fontFamily: "inherit",
+        fontSize: 24,
         fontWeight: 700,
       },
       labelNumber: {
@@ -70,6 +82,12 @@ export function getStyles() {
       // AWS WIDGET BAR STYLES
       AWSBar: {
         data: { fill: BLUE_COLOR },
+        labels: { fill: WHITE_COLOR, fontSize: "12px" }
+      },
+
+      // GOOGLE CLOUD COST WIDGET BAR STYLES
+      GCPBar: {
+        data: { fill: RED_COLOR },
         labels: { fill: WHITE_COLOR, fontSize: "12px" }
       }
     };

--- a/src/styles.tsx
+++ b/src/styles.tsx
@@ -1,13 +1,14 @@
 export function getStyles() {
     const WHITE_COLOR = "#FFFFFF";
     const BLACK_COLOR = "#000000"
-    const BLUE_COLOR = "#00a3de";
+    const BLUE_COLOR = "#367BBC";
     const RED_COLOR = "#7c270b";
     const AXIS_COLOR = "#FFFFFF";
     const LIGHTGRAY_COLOR = "#f0efef";
     const BLACKDARK_COLOR = "#1A1B1E";
     const BLACKLIGHT_COLOR = "#292A29";
     const GREEN_COLOR = "#31D397";
+
 
     return {
       title: {
@@ -37,11 +38,9 @@ export function getStyles() {
         }
       },
 
-      // DATA SET ONE
+      // DEPENDANT AXIS
       axisOne: {
-        grid: {
-          strokeWidth: 0
-        },
+        grid: { strokeWidth: 0 },
         axis: { stroke: AXIS_COLOR, strokeWidth: 1 }, 
         ticks: { stroke: AXIS_COLOR , strokeWidth: 1 },
         tickLabels: {
@@ -51,9 +50,26 @@ export function getStyles() {
         }
       },
 
+      axisTwo: {
+        grid: { strokeWidth: 0 },
+        axis: { stroke: AXIS_COLOR, strokeWidth: 1 }, 
+        ticks: { stroke: AXIS_COLOR , strokeWidth: 1 },
+        tickLabels: {
+          fill: AXIS_COLOR,
+          fontFamily: "inherit",
+          fontSize: "10px",
+        }
+      },
+
       // HEROKU WIDGET BAR STYLES
       herokuBar: {
         data: { fill: GREEN_COLOR },
+        labels: { fill: WHITE_COLOR, fontSize: "12px" }
+      },
+
+      // AWS WIDGET BAR STYLES
+      AWSBar: {
+        data: { fill: BLUE_COLOR },
         labels: { fill: WHITE_COLOR, fontSize: "12px" }
       }
     };

--- a/src/styles.tsx
+++ b/src/styles.tsx
@@ -8,6 +8,7 @@ export function getStyles() {
     const BLACKDARK_COLOR = "#1A1B1E";
     const BLACKLIGHT_COLOR = "#292A29";
     const GREEN_COLOR = "#31D397";
+    const YELLOW_COLOR = "#F0C656"
 
 
     return {
@@ -27,6 +28,12 @@ export function getStyles() {
         fill: WHITE_COLOR,
         fontFamily: "inherit",
         fontSize: 24,
+        fontWeight: 700,
+      },
+      MemoryTitle: {
+        fill: WHITE_COLOR,
+        fontFamily: "inherit",
+        fontSize: 28,
         fontWeight: 700,
       },
       labelNumber: {
@@ -88,6 +95,13 @@ export function getStyles() {
       // GOOGLE CLOUD COST WIDGET BAR STYLES
       GCPBar: {
         data: { fill: RED_COLOR },
+        labels: { fill: WHITE_COLOR, fontSize: "12px" }
+      },
+
+      // TOTAL MEMORY WIDGET BAR STYLES
+      MemoryLine: {
+        data: { stroke: YELLOW_COLOR, strokeWidth: 6 },
+        parent: { border: "1px solid #ccc" },
         labels: { fill: WHITE_COLOR, fontSize: "12px" }
       }
     };

--- a/src/widgets/AwsCost.tsx
+++ b/src/widgets/AwsCost.tsx
@@ -73,14 +73,15 @@ export default class AwsCost extends React.Component<Props, State> {
         <VictoryChart
           //theme={VictoryTheme.material}
           domainPadding={30}
-          height={350}
+          height={300}
+          width={375}
           style={{
-            parent: { border: "1px solid #000", background: "#292A29" }
+            parent: { background: "#292A29" }
           }}
         >
           <VictoryLabel
             text="AWS cost per month"
-            style={styles.title}
+            style={styles.AWSTitle}
             x={47}
             y={15}
           />
@@ -97,6 +98,7 @@ export default class AwsCost extends React.Component<Props, State> {
             data={this.getData()}
             labels={(d) => (`$${d.y.toFixed(2)}`)}
             style={styles.AWSBar}
+            barWidth={30}
             labelComponent={
               <VictoryLabel
                 style={styles.AWSBar.labels}

--- a/src/widgets/AwsCost.tsx
+++ b/src/widgets/AwsCost.tsx
@@ -5,6 +5,7 @@ import {
   VictoryBar, VictoryChart, VictoryAxis,
   VictoryTheme, VictoryLabel
 } from 'victory';
+import { getStyles } from '../styles'
 
 interface Payload {
   data: any;
@@ -47,7 +48,7 @@ export default class AwsCost extends React.Component<Props, State> {
       return 0;
     });
 
-    return chartData.map((p:any) => {
+    return chartData.slice(-5).map((p:any) => {
       const month = p.TimePeriod.Start.split("-")
       return {
         x: `${month[0].slice(-2)}-${month[1]}`,
@@ -65,42 +66,40 @@ export default class AwsCost extends React.Component<Props, State> {
     }
 
     const { area } = this.props;
+    const styles = getStyles();
 
     return (
-      <Cell center area={area} style={{ backgroundColor: "#fff" }}>
+      <Cell center area={area} style={{ backgroundColor: "#292A29" }}>
         <VictoryChart
-          theme={VictoryTheme.material}
-          domainPadding={40}
+          //theme={VictoryTheme.material}
+          domainPadding={30}
+          height={350}
           style={{
-            parent: { border: "1px solid #ccc" }
+            parent: { border: "1px solid #000", background: "#292A29" }
           }}
         >
           <VictoryLabel
             text="AWS cost per month"
-            style={{
-              fontSize: "20px"
-            }}
-            x={10}
-            y={20}
+            style={styles.title}
+            x={47}
+            y={15}
           />
           <VictoryAxis
-            style={{
-              tickLabels: { fontSize: '9px' }
-            }}
+            style={styles.axisOne}
             padding={20}
           />
           <VictoryAxis
             dependentAxis
             tickFormat={(x) => (`$${x}`)}
+            style={styles.axisTwo}
           />
           <VictoryBar
             data={this.getData()}
             labels={(d) => (`$${d.y.toFixed(2)}`)}
+            style={styles.AWSBar}
             labelComponent={
               <VictoryLabel
-                style={{
-                  fontSize: "11px"
-                }}
+                style={styles.AWSBar.labels}
               />
             }
           />

--- a/src/widgets/GoogleCloudCost.tsx
+++ b/src/widgets/GoogleCloudCost.tsx
@@ -5,6 +5,7 @@ import {
   VictoryBar, VictoryChart, VictoryAxis,
   VictoryTheme, VictoryLabel, VictoryStack
 } from 'victory';
+import { getStyles } from '../styles'
 
 
 interface CostItem {
@@ -69,41 +70,41 @@ export default class GoogleCloudCost extends React.Component<Props, State> {
 
     const data: Payload = this.state.payload;
     const { area } = this.props;
+    const styles = getStyles();
+
     return (
-      <Cell area={area}>
+      <Cell area={area} style={{ backgroundColor: "#292A29", paddingLeft: "20px" }}>
         <VictoryChart
-          theme={VictoryTheme.material}
-          domainPadding={20}
+          domainPadding={75}
+          height={280}
+          width={350}
           style={{
-            parent: { border: "1px solid #ccc" }
+            parent: { background: "#292A29" }
           }}
         >
           <VictoryLabel
             text="GCP cost per month"
-            style={{
-              fontSize: "20px"
-            }}
-            x={10}
+            style={styles.GCPTitle}
+            x={47}
             y={20}
           />
           <VictoryAxis
-            style={{
-              tickLabels: { fontSize: '9px' }
-            }}
+            style={styles.axisOne}
             padding={20}
           />
           <VictoryAxis
             dependentAxis
             tickFormat={(x) => (`$${x.toFixed(2)}`)}
+            style={styles.axisYears}
           />
           <VictoryBar
             data={this.getData()}
             labels={(d) => (`$${d.y.toFixed(2)}`)}
+            barWidth={40}
+            style={styles.GCPBar}
             labelComponent={
               <VictoryLabel
-                style={{
-                  fontSize: "9px"
-                }}
+                style={styles.GCPBar.labels}
               />
             }
           />

--- a/src/widgets/HerokuCost.tsx
+++ b/src/widgets/HerokuCost.tsx
@@ -92,12 +92,12 @@ export default class HerokuCost extends React.Component<Props, State> {
             domainPadding={30}
             height={350}
             style={{
-              parent: { border: "1px solid #000", background: "#292A29" }
+              parent: { background: "#292A29" }
             }}
           >
             <VictoryLabel
               text="Heroku cost per month"
-              style={styles.title}
+              style={styles.herokuTitle}
               x={47}
               y={15}
             />

--- a/src/widgets/ServerMemory.tsx
+++ b/src/widgets/ServerMemory.tsx
@@ -8,6 +8,7 @@ import {
   VictoryLine,
   VictoryTheme
 } from 'victory';
+import { getStyles } from '../styles'
 
 interface Payload {
   data: {
@@ -70,34 +71,33 @@ export default class ServerMemory extends React.Component<Props, State> {
     }
     
     const { area } = this.props;
+    const styles = getStyles();
+
     return (
-      <Cell area={area}>
+      <Cell area={area} style={{ backgroundColor: "#292A29", paddingLeft: "20px" }}>
         <VictoryChart
-          theme={VictoryTheme.material}
+          height={350}
           style={{
-            parent: { border: "1px solid #ccc" }
+            parent: { background: "#292A29" }
           }}
         >
           <VictoryLabel
             text="Total memory usage"
-            style={{
-              fontSize: "20px"
-            }}
-            x={10}
-            y={20}
+            style={styles.MemoryTitle}
+            x={47}
+            y={15}
           />
           <VictoryAxis
+          style={styles.axisOne}
           />
           <VictoryAxis
             dependentAxis
             tickFormat={(x:number) => (`${x.toFixed(2)} MB`)}
+            style={styles.axisYears}
           />
           <VictoryLine
             interpolation="natural"
-            style={{
-              data: { stroke: "#c43a31" },
-              parent: { border: "1px solid #ccc" }
-            }}
+            style={styles.MemoryLine}
             data={this.getData()}
           />
         </VictoryChart>


### PR DESCRIPTION
## This PR consists of the following:

### Applying theme styles to the other widgets:
- Pulling getStyles() into the other widgets
- Creating custom Titles for each widget as resizing eliminates all `fontSize` accuracy (kind of a hacky work around :S)
- Importing other colors that go well with the dark UI, this color will distinguish it from the other widgets and will be the fill color for the data elements on each widget
- Setting desired height and width for each `Chart` element (these will vary depending on how much data is being rendered by each widget")

| Before | After |
|--------|-------|
|    ![Screen Shot 2019-04-02 at 20 36 44](https://user-images.githubusercontent.com/30609058/55445107-a8a76780-5587-11e9-8b51-8a43d2b8039c.png)    |   ![Screen Shot 2019-04-02 at 20 36 49](https://user-images.githubusercontent.com/30609058/55445108-a8a76780-5587-11e9-9706-890f7bbf6ee9.png)    |



