### PR TITLE
Header + Cell Border (no queries yet)

### DIFF
--- a/src/Cost.tsx
+++ b/src/Cost.tsx
@@ -65,7 +65,7 @@ class Cost extends React.Component<RouteComponentProps, State> {
             this.state.width > 900 ? ["a b c", "d e f"] : ["a b", "c d", "e f"]
           }
           columns="3"
-          gap="1px"
+          gap="0px"
         >
           <HerokuCost
             screenHeight={this.state.height}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@
 import { jsx, css } from '@emotion/core'
 import React from "react";
 import ReactDOM from "react-dom";
+import CdsLogo from './CdsLogo'
 import "./index.css";
 import Cost from "./Cost";
 import Vac from "./Vac";
@@ -10,24 +11,50 @@ import * as serviceWorker from "./serviceWorker";
 import { Router, Link } from "@reach/router";
 
 const header = css`
-  margin-left: 10px;
+  background: black;
+  padding: 2rem;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  svg {
+    width: 4rem;
+  }
+
+  h1 {
+    color: white;
+    margin: 0;
+    line-height: 1.2rem;
+    margin-bottom: 1rem;
+  }
 `
+
 const navStyle = css`
-  margin-bottom: 20px;
+  color: white;
+
+  a{ 
+    color: white;
+  }
 `;
 
 
 const App = () => (
   <div>
     <div css={header}>
-      <h1>Dashboard</h1>
-      <nav css={navStyle}>
-      <Link to="/">Home</Link>
-        &nbsp; | &nbsp;
-        <Link to="/cost">Cost Dashboard</Link>
-        &nbsp; | &nbsp;
-        <Link to="/vac">VAC Dashboard</Link>
-      </nav>
+      <div>
+        <h1>Loon Dashboard UI (alpha banner)</h1>
+        <nav css={navStyle}>
+        <Link to="/">Home</Link>
+          &nbsp; | &nbsp;
+          <Link to="/cost">Cost Dashboard</Link>
+          &nbsp; | &nbsp;
+          <Link to="/vac">VAC Dashboard</Link>
+        </nav>
+      </div>
+      <div>
+        <CdsLogo />
+      </div>
     </div>
     <Router>
       <Home path="/" />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import * as serviceWorker from "./serviceWorker";
 import { Router, Link } from "@reach/router";
 
 const header = css`
-  background: black;
+  background: #171717;
   padding: 2rem;
 
   display: flex;
@@ -26,7 +26,7 @@ const header = css`
     color: white;
     margin: 0;
     line-height: 1.2rem;
-    margin-bottom: 1rem;
+    margin-bottom: 1.4rem;
   }
 `
 

--- a/src/styles.tsx
+++ b/src/styles.tsx
@@ -137,6 +137,6 @@ export const WidgetTitle = styled.h3`
 
 export const Panel = styled.div`
   text-align: center;
-  border: 2px solid black;
+  border: 2px solid #171717;
   color: white;
 `

--- a/src/styles.tsx
+++ b/src/styles.tsx
@@ -137,6 +137,6 @@ export const WidgetTitle = styled.h3`
 
 export const Panel = styled.div`
   text-align: center;
-  border: 1px solid white;
+  border: 2px solid black;
   color: white;
 `


### PR DESCRIPTION
## This PR consists of the following:

### Updating Header + Cell Styles:
- Header color has changed to black
- Logo component from earlier PR moved in
- Font styling
- Cell border changed to black, grid gap reduced to 0px, border thickness bumped to 2px

| Before | After |
|--------|-------|
|   <img width="1356" alt="Screen Shot 2019-04-17 at 13 40 18" src="https://user-images.githubusercontent.com/30609058/56308919-69941d00-6116-11e9-846c-55195cb44a5b.png">| <img width="1356" alt="Screen Shot 2019-04-17 at 13 39 52" src="https://user-images.githubusercontent.com/30609058/56308918-69941d00-6116-11e9-97b6-c03db0d8b6ce.png">  |



