### PR TITLE
Header Styles 2.0 (still no queries)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,61 +1,18 @@
-/** @jsx jsx */
-import { jsx, css } from '@emotion/core'
+/** @jsx jsx */ jsx;
+import { jsx, css } from "@emotion/core";
 import React from "react";
 import ReactDOM from "react-dom";
-import CdsLogo from './CdsLogo'
+import PageHeader from './widgets/PageHeader';
 import "./index.css";
 import Cost from "./Cost";
 import Vac from "./Vac";
 import Home from "./Home";
 import * as serviceWorker from "./serviceWorker";
-import { Router, Link } from "@reach/router";
-
-const header = css`
-  background: #171717;
-  padding: 2rem;
-
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  svg {
-    width: 4rem;
-  }
-
-  h1 {
-    color: white;
-    margin: 0;
-    line-height: 1.2rem;
-    margin-bottom: 1.4rem;
-  }
-`
-
-const navStyle = css`
-  color: white;
-
-  a{ 
-    color: white;
-  }
-`;
-
+import { Router } from "@reach/router";
 
 const App = () => (
   <div>
-    <div css={header}>
-      <div>
-        <h1>Loon Dashboard UI (alpha banner)</h1>
-        <nav css={navStyle}>
-        <Link to="/">Home</Link>
-          &nbsp; | &nbsp;
-          <Link to="/cost">Cost Dashboard</Link>
-          &nbsp; | &nbsp;
-          <Link to="/vac">VAC Dashboard</Link>
-        </nav>
-      </div>
-      <div>
-        <CdsLogo />
-      </div>
-    </div>
+    <PageHeader />
     <Router>
       <Home path="/" />
       <Cost path="/cost" />

--- a/src/styles.tsx
+++ b/src/styles.tsx
@@ -15,36 +15,6 @@ export function getStyles() {
 
 
     return {
-      herokuTitle: {
-        fill: WHITE_COLOR,
-        fontFamily: "inherit",
-        fontSize: 28,
-        fontWeight: 700,
-      },
-      AWSTitle: {
-        fill: WHITE_COLOR,
-        fontFamily: "inherit",
-        fontSize: 24,
-        fontWeight: 700,
-      },
-      AzureTitle: {
-        fill: WHITE_COLOR,
-        fontFamily: "inherit",
-        fontSize: 24,
-        fontWeight: 700,
-      },
-      GCPTitle: {
-        fill: WHITE_COLOR,
-        fontFamily: "inherit",
-        fontSize: 24,
-        fontWeight: 700,
-      },
-      MemoryTitle: {
-        fill: WHITE_COLOR,
-        fontFamily: "inherit",
-        fontSize: 28,
-        fontWeight: 700,
-      },
       labelNumber: {
         fill: "#ffffff",
         fontFamily: "inherit",

--- a/src/widgets/PageHeader.tsx
+++ b/src/widgets/PageHeader.tsx
@@ -1,0 +1,55 @@
+/** @jsx jsx */
+import { jsx, css } from "@emotion/core";
+import React from "react";
+import { Link } from "@reach/router";
+import CdsLogo from "../CdsLogo";
+
+const navStyle = css`
+color: white;
+
+a {
+  color: white;
+}
+`;
+
+const header = css`
+background: #171717;
+padding: 2rem;
+
+display: flex;
+justify-content: space-between;
+align-items: center;
+
+svg {
+  width: 4rem;
+}
+
+h1 {
+  color: white;
+  margin: 0;
+  line-height: 1.2rem;
+  margin-bottom: 1.4rem;
+}
+`;
+
+const PageHeader = () => {
+  return (
+    <div css={header}>
+        <div>
+            <h1>Loon Dashboard UI (alpha banner)</h1>
+            <nav css={navStyle}>
+                <Link to="/">Home</Link>
+                &nbsp; | &nbsp;
+                <Link to="/cost">Cost Dashboard</Link>
+                &nbsp; | &nbsp;
+                <Link to="/vac">VAC Dashboard</Link>
+            </nav>
+        </div>
+        <div>
+          <CdsLogo />
+        </div>
+    </div>
+  );
+};
+
+export default PageHeader;

--- a/src/widgets/PageHeader.tsx
+++ b/src/widgets/PageHeader.tsx
@@ -3,6 +3,7 @@ import { jsx, css } from "@emotion/core";
 import React from "react";
 import { Link } from "@reach/router";
 import CdsLogo from "../CdsLogo";
+import PhaseBadge from "./PhaseBadge"
 
 const navStyle = css`
 color: white;
@@ -31,27 +32,11 @@ h1 {
 }
 `;
 
-const phaseBadge = css`
-  background: #f90277;
-  font-size: 1.2rem;
-  border-radius: 0.5rem;
-  color: white;
-  font-weight: 700;
-  padding: 0.2rem 0.8rem;
-  margin-left: 1rem;
-`
-
 const titleContainer = css`
   display: flex;
   margin-bottom: 1rem;
   align-items: center;
 `
-
-const PhaseBadge = () => {
-    return (
-      <span css={phaseBadge}>Alpha</span>
-    );
-  };
 
 const PageHeader = () => {
   return (

--- a/src/widgets/PageHeader.tsx
+++ b/src/widgets/PageHeader.tsx
@@ -28,15 +28,39 @@ h1 {
   color: white;
   margin: 0;
   line-height: 1.2rem;
-  margin-bottom: 1.4rem;
 }
 `;
+
+const phaseBadge = css`
+  background: #f90277;
+  font-size: 1.2rem;
+  border-radius: 0.5rem;
+  color: white;
+  font-weight: 700;
+  padding: 0.2rem 0.8rem;
+  margin-left: 1rem;
+`
+
+const titleContainer = css`
+  display: flex;
+  margin-bottom: 1rem;
+  align-items: center;
+`
+
+const PhaseBadge = () => {
+    return (
+      <span css={phaseBadge}>Alpha</span>
+    );
+  };
 
 const PageHeader = () => {
   return (
     <div css={header}>
         <div>
-            <h1>Loon Dashboard UI (alpha banner)</h1>
+            <div css={titleContainer}>
+                <h1>Loon Dashboard UI</h1>
+                <PhaseBadge />
+            </div>
             <nav css={navStyle}>
                 <Link to="/">Home</Link>
                 &nbsp; | &nbsp;

--- a/src/widgets/PhaseBadge.tsx
+++ b/src/widgets/PhaseBadge.tsx
@@ -1,0 +1,21 @@
+/** @jsx jsx */
+import { jsx, css } from "@emotion/core";
+import React from "react";
+
+const phaseBadge = css`
+  background: #f90277;
+  font-size: 1.2rem;
+  border-radius: 0.5rem;
+  color: white;
+  font-weight: 700;
+  padding: 0.2rem 0.8rem;
+  margin-left: 1rem;
+`
+
+const PhaseBadge = () => {
+    return (
+      <span css={phaseBadge}>Alpha</span>
+    );
+  };
+
+export default PhaseBadge;


### PR DESCRIPTION
## This PR consists of the following:

### More header restyling:
- Moving the page header HTML + CSS into it's own component
- Creating a Phase Badge component
- Adding this phase badge component to the current PageHeader component

*** ***Still need to add queries*** ***

| Before | After |
|--------|-------|
|  <img width="1392" alt="Screen Shot 2019-04-18 at 14 01 54" src="https://user-images.githubusercontent.com/30609058/56381341-91e94d80-61e2-11e9-8495-f7a9ed50a267.png">   |  <img width="1392" alt="Screen Shot 2019-04-18 at 14 02 44" src="https://user-images.githubusercontent.com/30609058/56381385-b6452a00-61e2-11e9-9687-9578cd765484.png"> |

